### PR TITLE
Automatically publish docs to shardingsphere-doc repository when released.

### DIFF
--- a/.github/scripts/build-website.sh
+++ b/.github/scripts/build-website.sh
@@ -53,7 +53,7 @@ if [ ${#TAGS} -gt 0 ] ; then
 fi
 
 # generate version data
-echo "[\""$(echo ${TAGS[@]} |xargs|sed 's/ /","/g')"\"]" > ../versions.json
+echo "[\""$(echo ${TAGS[@]}|sed 's/shardingsphere-doc-//g'|xargs|sed 's/ /","/g')"\"]" > ../versions.json
 
 
 # -----------------------------------------------------------------------------------

--- a/.github/scripts/build-website.sh
+++ b/.github/scripts/build-website.sh
@@ -77,7 +77,6 @@ else
     mv _shardingsphere/new_version_ss ./old_version_ss
     
     cp -rf _shardingsphere/docs ./
-    rm -rf _shardingsphere
     mv docs ssdocs
     
     echo build hugo ss documents
@@ -117,6 +116,7 @@ else
     
     rm -rf sstarget
 fi
+rm -rf _shardingsphere
 
 #######################################
 ##  SHARDINGSPHERE-ELASTICJOB/DOCS   ##

--- a/.github/scripts/build-website.sh
+++ b/.github/scripts/build-website.sh
@@ -61,7 +61,6 @@ echo check diff
 if  [ ! -s old_version_ss ]  ; then
     echo init > old_version_ss 
 fi
-cd _shardingsphere
 git checkout master
 git log -1 -p docs > new_version_ss
 diff ../old_version_ss new_version_ss > result_version

--- a/.github/scripts/build-website.sh
+++ b/.github/scripts/build-website.sh
@@ -32,13 +32,13 @@ git clone https://github.com/apache/shardingsphere _shardingsphere
 
 # ------------------------- build history docs --------------------------------------
 cd _shardingsphere
-TAGS=(`git tag --sort=-taggerdate -l 'shardingsphere-doc-*'`)
+TAGS=(`git tag --sort=taggerdate -l 'shardingsphere-doc-*'`)
 
 # generate released document
 if [ ${#TAGS} -gt 0 ] ; then
   for tag in ${TAGS[@]}
   do
-    if [ ! -d ../document/$tag ] ; then
+    if [ ! -d ../document/$(echo $tag|sed 's/shardingsphere-doc-//g') ] ; then
       count=1
       echo "generate $tag documnet"
       git checkout $tag

--- a/.github/scripts/build-website.sh
+++ b/.github/scripts/build-website.sh
@@ -45,7 +45,7 @@ if [ ${#TAGS} -gt 0 ] ; then
       dir=$(echo $tag|sed 's/shardingsphere-doc-//g')
       env HUGO_BASEURL="https://shardingsphere.apache.org/document/$dir/" \
         HUGO_PARAMS_EDITURL="" \
-        sh docs/build.sh
+        bash docs/build.sh
       find docs/target/document/current -name '*.html' -exec sed -i -e 's|<option id="\([a-zA-Z]\+\)" value="/document/current|<option id="\1" value="/document/'$dir'|g' {} \;
       mv docs/target/document/current/ ../document/$dir
     fi

--- a/.github/scripts/build-website.sh
+++ b/.github/scripts/build-website.sh
@@ -28,7 +28,7 @@ export TZ="Asia/Shanghai"
 echo "[1] ====>>>> process shardingsphere/docs"
 echo git clone https://github.com/apache/shardingsphere
 
-git clone https://github.com/qiliangfan/shardingsphere _shardingsphere 
+git clone https://github.com/apache/shardingsphere _shardingsphere 
 
 # ------------------------- build history docs --------------------------------------
 cd _shardingsphere

--- a/.github/scripts/build-website.sh
+++ b/.github/scripts/build-website.sh
@@ -28,7 +28,7 @@ export TZ="Asia/Shanghai"
 echo "[1] ====>>>> process shardingsphere/docs"
 echo git clone https://github.com/apache/shardingsphere
 
-git clone https://github.com/apache/shardingsphere _shardingsphere 
+git clone https://github.com/fanqiliang/shardingsphere _shardingsphere 
 
 # ------------------------- build history docs --------------------------------------
 cd _shardingsphere

--- a/.github/scripts/build-website.sh
+++ b/.github/scripts/build-website.sh
@@ -28,7 +28,7 @@ export TZ="Asia/Shanghai"
 echo "[1] ====>>>> process shardingsphere/docs"
 echo git clone https://github.com/apache/shardingsphere
 
-git clone https://github.com/fanqiliang/shardingsphere _shardingsphere 
+git clone https://github.com/qiliangfan/shardingsphere _shardingsphere 
 
 # ------------------------- build history docs --------------------------------------
 cd _shardingsphere

--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -41,4 +41,4 @@ jobs:
     - name: Run a multi-line script
       run: |
         echo start to deploy ss doc...
-        sh .github/scripts/build-website.sh
+        bash .github/scripts/build-website.sh

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
               Document<em class="i-d-caret"></em>
               <div class="i-drop-pop">
                 <a class="i-drop-list" href="https://shardingsphere.apache.org/document/current/en/overview"
-                  target="_blank">5.x(Current)</a>
+                  target="_blank">master</a>
                 <a class="i-drop-list" href="https://shardingsphere.apache.org/document/legacy/4.x/document/en/overview"
                   target="_blank">4.x(Legacy)</a>
                 <a class="i-drop-list" href="https://shardingsphere.apache.org/document/legacy/3.x/document/en/overview"

--- a/index.html
+++ b/index.html
@@ -364,6 +364,10 @@
       },
     });
   </script>
+
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="/js/document.js"></script>
+
   <!-- chosen color of the pagination -->
   <style type="text/css">
     .my-bullet-active {

--- a/index_m.html
+++ b/index_m.html
@@ -50,7 +50,7 @@
           </div>
           <div class="i-drop-pop">
             <a class="i-drop-list" href="https://shardingsphere.apache.org/document/current/en/overview"
-              target="_blank">5.x(Current)</a>
+              target="_blank">master</a>
             <a class="i-drop-list" href="https://shardingsphere.apache.org/document/legacy/4.x/document/en/overview"
               target="_blank">4.x(Legacy)</a>
             <a class="i-drop-list" href="https://shardingsphere.apache.org/document/legacy/3.x/document/en/overview"

--- a/index_m.html
+++ b/index_m.html
@@ -334,6 +334,10 @@
       },
     });
   </script>
+
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="/js/document.js"></script>
+
   <!-- chosen color of the pagination -->
   <style type="text/css">
     .my-bullet-active {

--- a/index_m_zh.html
+++ b/index_m_zh.html
@@ -52,7 +52,7 @@
           </div>
           <div class="i-drop-pop">
             <a class="i-drop-list" href="https://shardingsphere.apache.org/document/current/cn/overview"
-              target="_blank">5.x(当前)</a>
+              target="_blank">master</a>
             <a class="i-drop-list" href="https://shardingsphere.apache.org/document/legacy/4.x/document/cn/overview"
               target="_blank">4.x(遗留)</a>
             <a class="i-drop-list" href="https://shardingsphere.apache.org/document/legacy/3.x/document/cn/overview"

--- a/index_m_zh.html
+++ b/index_m_zh.html
@@ -328,6 +328,10 @@
       },
     });
   </script>
+
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="/js/document.js"></script>
+
   <!-- chosen color of the pagination -->
   <style type="text/css">
     .my-bullet-active {

--- a/index_zh.html
+++ b/index_zh.html
@@ -56,7 +56,7 @@
               文档<em class="i-d-caret"></em>
               <div class="i-drop-pop">
                 <a class="i-drop-list" href="https://shardingsphere.apache.org/document/current/cn/overview"
-                  target="_blank">5.x(当前)</a>
+                  target="_blank">master</a>
                 <a class="i-drop-list" href="https://shardingsphere.apache.org/document/legacy/4.x/document/cn/overview"
                   target="_blank">4.x(遗留)</a>
                 <a class="i-drop-list" href="https://shardingsphere.apache.org/document/legacy/3.x/document/cn/overview"

--- a/index_zh.html
+++ b/index_zh.html
@@ -360,6 +360,10 @@
       },
     });
   </script>
+  
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="/js/document.js"></script>
+
   <!-- chosen color of the pagination -->
   <style type="text/css">
     .my-bullet-active {

--- a/js/document.js
+++ b/js/document.js
@@ -2,6 +2,7 @@ $(() => {
     $.ajax(
         "/versions.json", {
             success: res => {
+                res.reverse();
                 var parent_tag = $("#btn-document > .i-drop-pop");
                 var children = parent_tag.children("a");
                 var done = [];

--- a/js/document.js
+++ b/js/document.js
@@ -1,0 +1,35 @@
+$(() => {
+    $.ajax(
+        "/versions.json", {
+            success: res => {
+                var parent_tag = $("#btn-document > .i-drop-pop");
+                var children = parent_tag.children("a");
+                var done = [];
+
+                var last = null;
+                for (i = 0; i < children.length; i++) {
+                    for (j = 0; j < res.length; j++) {
+                        var tag = res[j].replace("shardingsphere-doc-", "")
+                        if( done.includes(tag) ) {
+                            continue
+                        }
+                        if (! children[i].href.includes(tag)) {
+                            done.push(tag)
+                            var new_node = $('<a class="i-drop-list" href="/document/' + tag + '/en/overview"  target="_blank">' + tag + '</a>)');
+                            if (last == null) {
+                                parent_tag.prepend(new_node);
+                                last = new_node
+                            } else {
+                                last.after(new_node);
+                                last = new_node;
+                            }
+                        } else {
+                            last = children[i];
+                        }
+                    }
+                }
+            },
+        }
+    )
+})
+

--- a/js/document.js
+++ b/js/document.js
@@ -9,6 +9,9 @@ $(() => {
 
                 var last = null;
                 for (i = 0; i < children.length; i++) {
+                    if($(children[i]).attr("href").includes("/document/current")) {
+                        last = $(children[i]);
+                    }
                     for (j = 0; j < res.length; j++) {
                         var tag = res[j].replace("shardingsphere-doc-", "")
                         if( done.includes(tag) ) {

--- a/versions.json
+++ b/versions.json
@@ -1,0 +1,1 @@
+["shardingsphere-doc-v1.1.0","shardingsphere-doc-v1.0.0"]

--- a/versions.json
+++ b/versions.json
@@ -1,1 +1,0 @@
-["shardingsphere-doc-v1.1.0","shardingsphere-doc-v1.0.0"]


### PR DESCRIPTION



Task one from: https://github.com/apache/shardingsphere/issues/9697

# :lantern: Features 

- For each tag with the pattern `shardingsphere-doc-*`,  scripts build the corresponding document . :bookmark_tabs: [build-website.sh](.github/scripts/build-website.sh)
- If there is a list item of a certain version of the document in the HTML that has not been created,  JavaScript will be used to create the list item of the corresponding document.:bookmark_tabs: [document.js](js/document.js)



#  :nut_and_bolt: How to use?

- In the repository `shardingsphere` , we need to create tags with pattern `shardingsphere-doc-*`, so in the repository `shardingsphere-doc` we create documents based on these tags.



# :dart: Test results:

- we tests this branch on :
  - https://github.com/QiliangFan/shardingsphere-doc
  - https://github.com/QiliangFan/shardingsphere

![test result](https://z3.ax1x.com/2021/09/04/hgGHW8.png)

- Self-test-demo can be found on: https://shardingsphere-doc.torch-fan.site/

![demo](https://z3.ax1x.com/2021/09/05/hWNkqS.png)

