### PR TITLE
Fix CI: Only deploy website on release events

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -18,12 +18,8 @@
 name: CI_Deploy_WebSite
 
 on:
-  push:
-    branches: [ asf-site ]
-  pull_request:
-    branches: [ asf-site ]
-  schedule:
-  - cron: '*/10 * * * *'
+  release:
+    types: [published]
 
 jobs:
   build:


### PR DESCRIPTION
This PR fixes #580.

Currently, the CI deploy workflow runs on `push` and `pull_request` to the `asf-site` branch, which also triggers builds for unreleased tags. This causes unreleased versions to appear in the official documentation.

### Changes:
- Updated `.github/workflows/build-website.yml`
- Workflow now triggers only on `release.published` events instead of push/PR/schedule.

### Result:
- Documentation is only deployed when a new release is published.
- Prevents unreleased versions from being deployed to the website.

